### PR TITLE
Fix projectId variable name

### DIFF
--- a/v1/guide/installation.html
+++ b/v1/guide/installation.html
@@ -387,7 +387,7 @@
 <td><code>false</code></td>
 </tr>
 <tr>
-<td>gcr.projectID</td>
+<td>gcr.projectId</td>
 <td>GCP Project ID GCR belongs to</td>
 <td></td>
 </tr>


### PR DESCRIPTION
Per the code - the correct name is "gcr.projectId".

https://github.com/keel-hq/keel/blob/ce61b44888ff65d37c03bf856e9b002f7cef32a0/chart/keel/templates/deployment.yaml#L68